### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-GitPython==0.3.6
+GitPython==0.3.4
 colorama==0.3.2
 termcolor==1.1.0
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 GitPython==0.3.6
-colorama==0.3.3
+colorama==0.3.2
 termcolor==1.1.0
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-GitPython==0.3.2.1
-colorama==0.3.2
+GitPython==0.3.6
+colorama==0.3.3
 termcolor==1.1.0
-docopt==0.6.1
+docopt==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version="1.2.2",
     packages=find_packages(exclude=["tests"]),
     scripts=['PyGitUp/gitup.py'],
-    install_requires=['GitPython==0.3.6', 'colorama==0.3.2',
+    install_requires=['GitPython==0.3.4', 'colorama==0.3.2',
                       'termcolor==1.1.0', 'docopt==0.6.2'],
 
     # Tests

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ setup(
     version="1.2.2",
     packages=find_packages(exclude=["tests"]),
     scripts=['PyGitUp/gitup.py'],
-    install_requires=['GitPython==0.3.2.1', 'colorama==0.3.2',
-                      'termcolor==1.1.0', 'docopt==0.6.1'],
+    install_requires=['GitPython==0.3.6', 'colorama==0.3.3',
+                      'termcolor==1.1.0', 'docopt==0.6.2'],
 
     # Tests
     test_suite="nose.collector",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version="1.2.2",
     packages=find_packages(exclude=["tests"]),
     scripts=['PyGitUp/gitup.py'],
-    install_requires=['GitPython==0.3.6', 'colorama==0.3.3',
+    install_requires=['GitPython==0.3.6', 'colorama==0.3.2',
                       'termcolor==1.1.0', 'docopt==0.6.2'],
 
     # Tests


### PR DESCRIPTION
I noticed there's some updates for GitPython, colorama and docopt.

Updating to the latest all the [tests pass on Travis](https://travis-ci.org/hugovk/PyGitUp/builds/52244732), but locally the colour doesn't work. Windows 7, Git Bash shows in monochrome:

```
$ python setup.py develop
...
$ git up
F←[0me←[0mt←[0mc←[0mh←[0mi←[0mn←[0mg←[0m ←[0mo←[0mr←[0mi←[0mg←[0mi←[0mn←[0m
←[0m←[0m←[1mmaster ←[0m←[0m ←[0m←[32mup to date←[0m←[0m
←[0m←[0m
```

Sticking with colorama 0.3.2 [passes on the CI](https://travis-ci.org/hugovk/PyGitUp/builds/52244732) and is correctly coloured locally:
```
$ python setup.py develop
...
$ git up
Fetching origin
stashing 2 changes
master  up to date
unstashing
```

(`*stashing` lines in purple, `up to date` in green.)
