### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
+  - "3.4"
+  - "3.3"
   - "2.7"
   - "2.6"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/PyGitUp/git_wrapper.py
+++ b/PyGitUp/git_wrapper.py
@@ -23,6 +23,8 @@ import subprocess
 import platform
 from contextlib import contextmanager
 
+import six
+
 # 3rd party libs
 from termcolor import colored  # Assume, colorama is already initialized
 from git import GitCommandError, CheckoutError as OrigCheckoutError, Git
@@ -84,7 +86,7 @@ class GitWrapper(object):
         """ Run a git command specified by name and args/kwargs. """
 
         tostdout = kwargs.pop('tostdout', False)
-        stdout = ''
+        stdout = six.b('')
 
         # Execute command
         cmd = getattr(self.git, name)(as_process=True, *args, **kwargs)
@@ -95,12 +97,12 @@ class GitWrapper(object):
 
             # Print to stdout
             if tostdout:
-                sys.stdout.write(output)
+                sys.stdout.write(output.decode('utf-8'))
                 sys.stdout.flush()
 
             stdout += output
 
-            if output == "":
+            if output == six.b(""):
                 break
 
         # Wait for the process to quit

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,7 @@ Otherwise pip will refuse to install ``git-up`` due to ``Access denied`` errors.
 Python 3 compatibility:
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-``PyGitUp`` is not compatible with Python 3 because some essential 3rd party
-libs don't support it. Sorry.
+Python 3.3 and 3.4 are supported.
 
 Options and Configuration
 -------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-GitPython==0.3.4
-colorama==0.3.2
+GitPython==0.3.6
+colorama==0.3.3
 termcolor==1.1.0
 docopt==0.6.2
+six==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,9 @@ setup(
     version="1.2.2",
     packages=find_packages(exclude=["tests"]),
     scripts=['PyGitUp/gitup.py'],
-    install_requires=['GitPython==0.3.4', 'colorama==0.3.2',
-                      'termcolor==1.1.0', 'docopt==0.6.2'],
+    install_requires=['GitPython==0.3.6', 'colorama==0.3.3',
+                      'termcolor==1.1.0', 'docopt==0.6.2',
+                      'six==1.9.0'],
 
     # Tests
     test_suite="nose.collector",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,7 +27,7 @@ def wip(f):
 @contextlib.contextmanager
 def capture():
     import sys
-    from cStringIO import StringIO
+    from six.moves import cStringIO as StringIO
     oldout, olderr = sys.stdout, sys.stderr
     out = None
     try:

--- a/tests/test_bundler.py
+++ b/tests/test_bundler.py
@@ -4,6 +4,8 @@ import platform
 import subprocess
 from os.path import join
 
+import six
+
 # 3rd party libs
 from nose.plugins.skip import SkipTest
 from git import *
@@ -55,7 +57,7 @@ def test_bundler():
             return False
 
     def get_output(cmd):
-        return subprocess.check_output(cmd, shell=shell)
+        return str(subprocess.check_output(cmd, shell=shell))
 
     # Check for ruby and bundler
     if not (is_installed('ruby') and is_installed('gem')

--- a/tests/test_not_on_a_git_repo.py
+++ b/tests/test_not_on_a_git_repo.py
@@ -14,7 +14,7 @@ repo_path = join(basepath, test_name + os.sep)
 
 
 def setup():
-    os.makedirs(repo_path, 0700)
+    os.makedirs(repo_path, 0o700)
 
 
 @raises(GitError)


### PR DESCRIPTION
Use the excellent `six` library to support both Python 2 and 3.
All tests passes on my machine for Python 3.4.3 and 2.7.9