### PR TITLE
Use full module path for entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Executable
     entry_points={
         'console_scripts': [
-            'git-up = gitup:run'
+            'git-up = PyGitUp.gitup:run'
         ]
     },
 


### PR DESCRIPTION
Gentoo does some different validation compared to Pip to install packages that use this method to specify entry point. I am not sure how Pip resolves this but when run from system pkg_resources just says there is no module named `gitup`. This fix seems to make it generate the correct entry point (which for me is at `/usr/lib64/python3.4/site-packages/git_up-1.3.0-py3.4.egg-info/entry_points.txt`.

```
$ cat /usr/lib64/python3.4/site-packages/git_up-1.3.0-py3.4.egg-info/entry_points.txt
[console_scripts]
git-up = PyGitUp.gitup:run
```

https://github.com/Tatsh/tatsh-overlay/blob/master/dev-vcs/git-up/git-up-1.3.0.ebuild