### PR TITLE
Correctly stash with submodules

### DIFF
--- a/PyGitUp/git_wrapper.py
+++ b/PyGitUp/git_wrapper.py
@@ -134,7 +134,7 @@ class GitWrapper(object):
         """
         stashed = False
 
-        if self.repo.is_dirty():
+        if self.repo.is_dirty(consider_submodules=False):
             if self.change_count > 1:
                 message = 'stashing {0} changes'
             else:

--- a/PyGitUp/git_wrapper.py
+++ b/PyGitUp/git_wrapper.py
@@ -188,10 +188,11 @@ class GitWrapper(object):
     @property
     def change_count(self):
         """ The number of changes in the working directory. """
-        return len(
-            self.git.status(porcelain=True, untracked_files='no').split(
-                '\n')
-        )
+        status = self.git.status(porcelain=True, untracked_files='no').strip()
+        if not status:
+            return 0
+        else:
+            return len(status.split('\n'))
 
     @property
     def version(self):

--- a/PyGitUp/git_wrapper.py
+++ b/PyGitUp/git_wrapper.py
@@ -134,7 +134,7 @@ class GitWrapper(object):
         """
         stashed = False
 
-        if self.repo.is_dirty(consider_submodules=False):
+        if self.repo.is_dirty(submodules=False):
             if self.change_count > 1:
                 message = 'stashing {0} changes'
             else:


### PR DESCRIPTION
I had a problem where a submodule has uncommitted changes. git up would choke on this, because `is_dirty` reports `True` but there isn't actually a change (the change count is 0, when correctly calculated, see below). Thus stashing would store an empty stash. Then on unstashing it fails because there is no stash. I provided gitpython-developers/GitPython#294 to GitPython to introduce a new argument that allows to ignore submodules when asking for `is_dirty`. This PR uses that change then.

Finally, I noticed the calculation of changes is off: If no change is made, the count would still be 1. Now it's correctly 0 (not something that would actually appear in reality, I guess).

Note that the PR on GitPython needs to be merged first. Beyond that, the version might need a bump in setup.py, but I guess you know that ;-)