### PR TITLE
Implement --no-fetch option

### DIFF
--- a/PyGitUp/gitup.py
+++ b/PyGitUp/gitup.py
@@ -2,7 +2,7 @@
 """
 git up -- like 'git pull', but polite
 
-Usage: git up [-h | --version | --quiet]
+Usage: git up [-h | --version | --quiet | --no-fetch | --no-f]
 
 Options:
   -h            Show this screen.
@@ -136,6 +136,7 @@ class GitUp(object):
             self.stderr = sys.stderr
 
         self.states = []
+        self.should_fetch = True
 
         # Check, if we're in a git repo
         try:
@@ -206,7 +207,8 @@ class GitUp(object):
     def run(self):
         """ Run all the git-up stuff. """
         try:
-            self.fetch()
+            if self.should_fetch:
+                self.fetch()
 
             with self.git.stash():
                 with self.returning_to_current_branch():
@@ -595,6 +597,9 @@ def run():  # pragma: no cover
 
         try:
             gitup = GitUp()
+
+            if arguments['--no-fetch'] or arguments['--no-f']:
+                gitup.should_fetch = False
         except GitError:
             sys.exit(1)  # Error in constructor
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -66,7 +66,7 @@ def write_file(path, contents):
 
 
 #noinspection PyDefaultArgument
-def update_file(repo, commit_message='', counter=[0]):
+def update_file(repo, commit_message='', testfile_name=testfile_name, counter=[0]):
     """
     Update 'testfile_name' using an increasing counter and commit the changes.
     """

--- a/tests/test_nofetch.py
+++ b/tests/test_nofetch.py
@@ -1,0 +1,70 @@
+# System imports
+import os
+from os.path import join
+
+# 3rd party libs
+from nose.tools import *
+from git import *
+
+# PyGitup imports
+from tests import basepath, capture, update_file, init_master
+
+test_name = 'no-fetch'
+new_branch_name = test_name + '.2'
+another_file_name = 'another_file.txt'
+
+origin_test_name = 'origin/' + test_name
+
+repo_path = join(basepath, test_name + os.sep)
+
+
+def setup():
+    master_path, master = init_master(test_name)
+
+    # Prepare master repo
+    master.git.checkout(b=test_name)
+
+    # Clone to test repo
+    path = join(basepath, test_name)
+    master.clone(path, b=test_name)
+
+    repo = Repo(path, odbt=GitCmdObjectDB)
+
+    assert repo.working_dir == path
+
+    # Create new local branch and set upstream
+    repo.git.checkout(b=new_branch_name)
+    repo.git.branch(u=origin_test_name)
+
+    # Make non-conflicting change in new branch
+    update_file(repo, new_branch_name, testfile_name=another_file_name)
+
+    # Modify file in master
+    update_file(master, test_name)
+
+    # Update first branch
+    repo.git.checkout(test_name)
+    repo.git.pull()
+
+
+
+def test_no_fetch():
+    """ Run 'git up' with '--no-fetch' argument """
+    os.chdir(repo_path)
+
+    from PyGitUp.gitup import GitUp
+    gitup = GitUp(testing=True)
+    gitup.should_fetch = False
+
+    with capture() as [stdout, _]:
+        gitup.run()
+
+    stdout = stdout.getvalue()
+
+    assert_false('Fetching' in stdout)
+
+    assert_true('rebasing' in stdout)
+    assert_true('up to date' in stdout)
+    assert_true(test_name in stdout)
+    assert_true(new_branch_name in stdout)
+


### PR DESCRIPTION
This option allows to rebase local branches without fetching remote (closes #29)