### PR TITLE
Remove scripts from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ setup(
     name="git-up",
     version="1.4.4",
     packages=find_packages(),
-    scripts=['PyGitUp/gitup.py'],
     install_requires=['GitPython>2.0.0', 'colorama>=0.3.7',
                       'termcolor>=1.1.0', 'click>=6.0.0',
                       'six>=1.10.0'],


### PR DESCRIPTION
There is already a console_scripts entrypoint which results in a script.
When installing to the system this results in /usr/bin/gitup.py and
/usr/bin/git-up.

Previously it was needed but 222cc6a9910f4fc44fd15a64da5db52a94d9a3c3
removed this requirement by using the full path.