### PR TITLE
Fix active branch highlighting

### DIFF
--- a/PyGitUp/gitup.py
+++ b/PyGitUp/gitup.py
@@ -218,12 +218,13 @@ class GitUp(object):
     def rebase_all_branches(self):
         """ Rebase all branches, if possible. """
         col_width = max(len(b.name) for b in self.branches) + 1
+        original_branch = self.repo.active_branch
 
         for branch in self.branches:
             target = self.target_map[branch.name]
 
             # Print branch name
-            if branch.name == self.repo.active_branch.name:
+            if branch.name == original_branch.name:
                 attrs = ['bold']
             else:
                 attrs = []


### PR DESCRIPTION
There is a bug in active branch highlighting.

Steps to reproduce:
1. Have branch `a` that needs a rebase
2. Be on branch `b`
3. Run `git up`.

Expected outcome:
> Fetching origin
> a           rebasing
> **b**           up to date
> returning to b

Actual outcome:
> Fetching origin
> a           rebasing
> b           up to date
> returning to b

