### PR TITLE
Upgrade to click>=7.0.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 GitPython = ">=2.1.8"
 colorama = ">=0.3.7"
 termcolor = ">=1.1.0"
-click = ">=6.0.0"
+click = ">=7.0.0"
 six = ">=1.10.0"
 
 [dev-packages]

--- a/PyGitUp/gitup.py
+++ b/PyGitUp/gitup.py
@@ -625,7 +625,7 @@ Project URL: https://github.com/msiemens/PyGitUp
 @click.option('-p', '--push/--no-push', default=None,
               help='Push the changes after pulling successfully.')
 @click.help_option('-h', '--help')
-def run(version, quiet, no_f, push, **kwargs):  # pragma: no cover
+def run(version, quiet, no_fetch, push, **kwargs):  # pragma: no cover
     """
     A nicer `git pull`.
     """
@@ -647,7 +647,7 @@ def run(version, quiet, no_f, push, **kwargs):  # pragma: no cover
             gitup.settings['push.auto'] = push
 
         # if arguments['--no-fetch'] or arguments['--no-f']:
-        if no_f:
+        if no_fetch:
             gitup.should_fetch = False
 
     except GitError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 GitPython>=2.1.8
 colorama>=0.3.7
 termcolor>=1.1.0
-click>=6.0.0
+click>=7.0.0
 six>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version="1.6.0",
     packages=find_packages(),
     install_requires=['GitPython>=2.1.8', 'colorama>=0.3.7',
-                      'termcolor>=1.1.0', 'click>=6.0.0,<7.0.0',
+                      'termcolor>=1.1.0', 'click>=7.0.0',
                       'six>=1.10.0'],
 
     # Tests


### PR DESCRIPTION
Click has changed the selection for parameter names (i.e., the shell-parameter-to-python parameter mapping) to select the **longest** option name first:

> The naming rules can be found in :ref:\`parameter_names\`. In short, you
> can refer the option \*\*implicitly\*\* by the longest dash-prefixed argument:

This needs to be reflected in `run()`; the code will no longer work with click <7.0.0, unfortunately.