### PR TITLE
Require click x.y rather than x.y.z

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version="1.6.1",
     packages=find_packages(),
     install_requires=['GitPython>=2.1.8', 'colorama>=0.3.7',
-                      'termcolor>=1.1.0', 'click>=7.0.0',
+                      'termcolor>=1.1.0', 'click>=7.0',
                       'six>=1.10.0'],
 
     # Tests


### PR DESCRIPTION
Click follows versioning with x.y rather than x.y.z. While most tools handle this consider 7.0 >= 7.0.0, it's not all. RPM has gained abilities to automatically generate dependencies for Python packages based on the metadata and doesn't handle this. Using the simple x.y form does work and doesn't impact other tools.