### PR TITLE
Support Python 3.7 and 3.8, drop 3.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Otherwise pip will refuse to install ``git-up`` due to ``Access denied`` errors.
 Python version compatibility:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Python 2.7, 3.4, 3.5 and 3.6 are supported :)
+Python 2.7, 3.5 and 3.6 are supported :)
 
 Options and Configuration
 -------------------------

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Otherwise pip will refuse to install ``git-up`` due to ``Access denied`` errors.
 Python version compatibility:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Python 2.7, 3.5 and 3.6 are supported :)
+Python 2.7, 3.5, 3.6, 3.7 and 3.8 are supported :)
 
 Options and Configuration
 -------------------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,17 +20,26 @@ strategy:
     Python37:
       python.version: '3.7'
       imageName: 'ubuntu-16.04'
+    Python38:
+      python.version: '3.8'
+      imageName: 'ubuntu-16.04'
     Mac_Python27:
       python.version: '2.7'
       imageName: 'macos-10.13'
     Mac_Python37:
       python.version: '3.7'
       imageName: 'macos-10.13'
+    Mac_Python38:
+      python.version: '3.8'
+      imageName: 'macos-10.13'
     Windows_Python27:
       python.version: '2.7'
       imageName: 'vs2017-win2016'
     Windows_Python37:
       python.version: '3.7'
+      imageName: 'vs2017-win2016'
+    Windows_Python38:
+      python.version: '3.8'
       imageName: 'vs2017-win2016'
 
 pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,6 @@ strategy:
     Python27:
       python.version: '2.7'
       imageName: 'ubuntu-16.04'
-    Python34:
-      python.version: '3.4'
-      imageName: 'ubuntu-16.04'
     Python35:
       python.version: '3.5'
       imageName: 'ubuntu-16.04'

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     license="MIT",
     keywords="git git-up",
     url="https://github.com/msiemens/PyGitUp",
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -44,7 +44,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Topic :: Software Development :: Version Control",

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Version Control",
         "Topic :: Utilities"
     ],


### PR DESCRIPTION
I didn't drop 3.4 from setup.py for now since there was no actual code change, but I don't know about the actual policy for this repo.