### PR TITLE
docs: Fix a few typos

### DIFF
--- a/PyGitUp/git_wrapper.py
+++ b/PyGitUp/git_wrapper.py
@@ -35,7 +35,7 @@ from PyGitUp.utils import find
 
 class GitWrapper:
     """
-    A wrapper for repo.git providing better stdout handling + better exeptions.
+    A wrapper for repo.git providing better stdout handling + better exceptions.
 
     It is preferred to repo.git because it doesn't print to stdout
     in real time. In addition, this wrapper provides better error

--- a/PyGitUp/gitup.py
+++ b/PyGitUp/gitup.py
@@ -65,7 +65,7 @@ def get_git_dir():
         # Not a normal git repo. Check if it's a submodule, then use
         # toplevel_dir. Otherwise it's a worktree, thus use  common_dir.
         # NOTE: git worktree support only comes with git v2.5.0 or
-        # later, on earler versions toplevel_dir is the best we can do.
+        # later, on earlier versions toplevel_dir is the best we can do.
 
         cmd = ['git', 'rev-parse', '--is-inside-work-tree']
         inside_worktree = execute(cmd, cwd=os.path.join(toplevel_dir, '..'))
@@ -131,7 +131,7 @@ class GitUp:
 
             self.repo = Repo(repo_dir, odbt=GitCmdObjectDB)
 
-        # Check for branch tracking informatino
+        # Check for branch tracking information
         if not any(b.tracking_branch() for b in self.repo.branches):
             exc = GitError("Can\'t update your repo because it doesn\'t has "
                            "any branches with tracking information.")
@@ -368,9 +368,9 @@ class GitUp:
                 # using multiple statements or things like 'echo'. Therefore,
                 # we write the string to a bat file and execute it.
 
-                # In addition, we replace occurences of $1 with %1 and so forth
+                # In addition, we replace occurrences of $1 with %1 and so forth
                 # in case the user is used to Bash or sh.
-                # If there are occurences of %something, we'll replace it with
+                # If there are occurrences of %something, we'll replace it with
                 # %%something. This is the case when running something like
                 # 'git log --pretty=format:"%Cred%h..."'.
                 # Also, we replace a semicolon with a newline, because if you

--- a/README.rst
+++ b/README.rst
@@ -241,7 +241,7 @@ v1.4.0 (*2016-02-29*)
 - Added an command line argument to turn of fetching (``--no-fetch``). Thanks `@buoto <https://github.com/buoto>`_
   for `Pull Request #46 <https://github.com/msiemens/PyGitUp/pull/46>`_.
 - Don't show a stacktrace anymore when stashing fails (`#35 <https://github.com/msiemens/PyGitUp/issues/35>`_).
-- Fixed a bug that cuased problems with submodules if the submodule had unstashed changes/ Thanks
+- Fixed a bug that caused problems with submodules if the submodule had unstashed changes/ Thanks
   `@Javex <https://github.com/Javex>`_ for `Pull Request #27 <https://github.com/msiemens/PyGitUp/pull/27>`_.
 
 v1.3.1 (*2015-08-31*)
@@ -318,7 +318,7 @@ v1.1.0 (*2013-10-07*)
   (``git up`` doesn't work with local only branches).
 
   **Note:**
-  This change may break setups, where a local branch accidently has
+  This change may break setups, where a local branch accidentally has
   the same name as a remote branch without any tracking information set. Prior
   to v1.1.0, ``git up`` would still fetch and rebase from the remote branch.
   If you run into troubles with such a setup, setting tracking information


### PR DESCRIPTION
There are small typos in:
- PyGitUp/git_wrapper.py
- PyGitUp/gitup.py
- README.rst

Fixes:
- Should read `occurrences` rather than `occurences`.
- Should read `information` rather than `informatino`.
- Should read `exceptions` rather than `exeptions`.
- Should read `earlier` rather than `earler`.
- Should read `caused` rather than `cuased`.
- Should read `accidentally` rather than `accidently`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md