### PR TITLE
Fix CI for forks: skip Coveralls uploads on forks due to failure when token not available

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -40,6 +40,7 @@ jobs:
         poetry run twine check dist/*
       if: matrix.os != 'windows-latest'
     - name: Upload coverage result
+      if: github.repository_owner == 'msiemens'
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: |


### PR DESCRIPTION
Avoid failures like this:

```
Run poetry run coveralls
Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
Traceback (most recent call last):
  File "/home/runner/.cache/pypoetry/virtualenvs/git-up-jBRg5r7u-py3.8/lib/python3.8/site-packages/coveralls/cli.py", line 61, in main
    coverallz = Coveralls(token_required,
  File "/home/runner/.cache/pypoetry/virtualenvs/git-up-jBRg5r7u-py3.8/lib/python3.8/site-packages/coveralls/api.py", line 54, in __init__
    name, job, number, pr = self.load_config_from_ci_environment()
  File "/home/runner/.cache/pypoetry/virtualenvs/git-up-jBRg5r7u-py3.8/lib/python3.8/site-packages/coveralls/api.py", line 149, in load_config_from_ci_environment
    name, job, number, pr = self.load_config_from_github()
  File "/home/runner/.cache/pypoetry/virtualenvs/git-up-jBRg5r7u-py3.8/lib/python3.8/site-packages/coveralls/api.py", line 99, in load_config_from_github
    raise CoverallsException(
coveralls.exception.CoverallsException: Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
Error: Process completed with exit code 1.
```

https://github.com/hugovk/PyGitUp/actions/runs/1233478736