### PR TITLE
Update subprocess handling to avoid hangs / blocking.

### DIFF
--- a/PyGitUp/tests/__init__.py
+++ b/PyGitUp/tests/__init__.py
@@ -65,9 +65,10 @@ def update_file(repo, commit_message='', counter=[0], filename=testfile_name):
 
     return path_file
 
+
 def mkrepo(path):
     """
-    Make a repository in 'path', create the the dir, if it doesn't exist.
+    Make a repository in 'path', create the dir, if it doesn't exist.
     """
     return Repo.init(path)
 

--- a/PyGitUp/tests/test_fetch_large_output.py
+++ b/PyGitUp/tests/test_fetch_large_output.py
@@ -1,0 +1,48 @@
+# System imports
+from os import sep, chdir
+from os.path import join
+import io
+
+from git import *
+
+from PyGitUp.tests import basepath, init_master
+
+TEST_NAME = 'fetch-large-output'
+REPO_PATH = join(basepath, TEST_NAME + sep)
+
+
+def setup():
+    master_path, master = init_master(TEST_NAME)
+
+    # Prepare master repo
+    master.git.checkout(b=TEST_NAME)
+
+    # Clone to test repo
+    path = join(basepath, TEST_NAME)
+
+    master.clone(path, b=TEST_NAME)
+    repo = Repo(path, odbt=GitCmdObjectDB)
+
+    assert repo.working_dir == path
+
+    # Generate lots of branches
+    total_branch_name_bytes = 0
+    for i in range(0, 1500):
+        branch_name = 'branch-name-%d' % i
+        total_branch_name_bytes += len(branch_name)
+        master.git.checkout(b=branch_name)
+
+
+def test_fetch_large_output():
+    """ Run 'git up' with a fetch that outputs lots of data """
+    # Arrange
+    chdir(REPO_PATH)
+    from PyGitUp.gitup import GitUp
+    gitup = GitUp(testing=True)
+
+    # Act
+    gitup.run()
+
+    # Assert
+    assert len(gitup.states) == 1
+    assert gitup.states[0] == 'up to date'


### PR DESCRIPTION
* Update subprocess handling to read both stdout and stderr (to avoid hangs based on blocked pipes).
* Add a unit test to cover that use case.
  * This test case would hang before the changes and now it does not.