### PR TITLE
Workaround for MinGW

### DIFF
--- a/PyGitUp/gitup.py
+++ b/PyGitUp/gitup.py
@@ -59,6 +59,8 @@ PYPI_URL = 'https://pypi.python.org/pypi/git-up/json'
 
 def get_git_dir():
     toplevel_dir = execute(['git', 'rev-parse', '--show-toplevel'])
+    if ON_WINDOWS and toplevel_dir[0] == '/':
+        toplevel_dir = execute(['cygpath', '-m', toplevel_dir])
 
     if toplevel_dir is not None \
             and os.path.isfile(os.path.join(toplevel_dir, '.git')):


### PR DESCRIPTION
Fix error like 'git.exc.NoSuchPathError: C:/c/Users/parrot/git/wp43'

The issue occurs after upgrading Python on MinGW64 to version 3.12.7

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:/msys64/mingw64/bin/git-up.exe/__main__.py", line 7, in <module>
  File "C:/msys64/mingw64/lib/python3.12/site-packages/PyGitUp/gitup.py", line 570, in run
    gitup = GitUp()
            ^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/PyGitUp/gitup.py", line 134, in __init__
    self.repo = Repo(repo_dir, odbt=GitCmdObjectDB)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/git/repo/base.py", line 236, in __init__
    raise NoSuchPathError(epath)
git.exc.NoSuchPathError: C:/c/Users/parrot/git/wp43
```