### PR TITLE
Mark compatible with termcolor 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 python = "^3.8"
 GitPython = "^3.0.0"
 colorama = "^0.4.0"
-termcolor = "^2.0.0"
+termcolor = ">= 2.0.0, < 4.0.0"
 
 [tool.poetry.dev-dependencies]
 coveralls = "^3.0.0"


### PR DESCRIPTION
The breaking changes do not affect git-up.

Link: https://github.com/termcolor/termcolor/releases/tag/3.0.0