### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,14 +16,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
     - name: Set up uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
     - name: Install dependencies
@@ -54,7 +54,7 @@ jobs:
     name: MinGW (MSYS2)
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up MSYS2 (MinGW64)
       uses: msys2/setup-msys2@v2
       with:

--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Set up uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "GitPython~=3.1",
-    "colorama~=0.4",
-    "packaging~=26.0",
-    "termcolor~=3.3",
+    "GitPython>=3.1",
+    "colorama>=0.4",
+    "packaging>=25.0",
+    "termcolor>=3.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 dependencies = [
     "GitPython~=3.1",
     "colorama~=0.4",
-    "packaging~=25.0",
-    "termcolor~=3.2",
+    "packaging~=26.0",
+    "termcolor~=3.3",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -267,8 +267,8 @@ dev = [
 requires-dist = [
     { name = "colorama", specifier = "~=0.4" },
     { name = "gitpython", specifier = "~=3.1" },
-    { name = "packaging", specifier = "~=25.0" },
-    { name = "termcolor", specifier = "~=3.2" },
+    { name = "packaging", specifier = "~=26.0" },
+    { name = "termcolor", specifier = "~=3.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -322,11 +322,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
 ]
 
 [[package]]
@@ -405,11 +405,11 @@ wheels = [
 
 [[package]]
 name = "termcolor"
-version = "3.2.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/56/ab275c2b56a5e2342568838f0d5e3e66a32354adcc159b495e374cda43f5/termcolor-3.2.0.tar.gz", hash = "sha256:610e6456feec42c4bcd28934a8c87a06c3fa28b01561d46aa09a9881b8622c58", size = 14423, upload-time = "2025-10-25T19:11:42.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/d5/141f53d7c1eb2a80e6d3e9a390228c3222c27705cbe7f048d3623053f3ca/termcolor-3.2.0-py3-none-any.whl", hash = "sha256:a10343879eba4da819353c55cb8049b0933890c2ebf9ad5d3ecd2bb32ea96ea6", size = 7698, upload-time = "2025-10-25T19:11:41.536Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -265,10 +265,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "colorama", specifier = "~=0.4" },
-    { name = "gitpython", specifier = "~=3.1" },
-    { name = "packaging", specifier = "~=26.0" },
-    { name = "termcolor", specifier = "~=3.3" },
+    { name = "colorama", specifier = ">=0.4" },
+    { name = "gitpython", specifier = ">=3.1" },
+    { name = "packaging", specifier = ">=25.0" },
+    { name = "termcolor", specifier = ">=3.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
I've also removed the upper bounds for library use. There's still the `uv.lock` for pinned dev use.

See https://iscinumpy.dev/post/bound-version-constraints/ for the long version.

The short version is it can cause problems for pip users. And uv even ignores upper caps.

